### PR TITLE
Release v0.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-01-01
+
+### Changed
+
+#### Repository
+- Rename repository from `backend-friendly-i18n` to `bf-i18n`
+- Update all package URLs (homepage, repository, bugs) to use new repository name
+
 ## [0.5.2] - 2026-01-01
 
 ### Added

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -23,14 +23,14 @@
   ],
   "author": "",
   "license": "MIT",
-  "homepage": "https://github.com/usapopopooon/backend-friendly-i18n#readme",
+  "homepage": "https://github.com/usapopopooon/bf-i18n#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/usapopopooon/backend-friendly-i18n.git",
+    "url": "git+https://github.com/usapopopooon/bf-i18n.git",
     "directory": "packages/cli"
   },
   "bugs": {
-    "url": "https://github.com/usapopopooon/backend-friendly-i18n/issues"
+    "url": "https://github.com/usapopopooon/bf-i18n/issues"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,14 +33,14 @@
   ],
   "author": "",
   "license": "MIT",
-  "homepage": "https://github.com/usapopopooon/backend-friendly-i18n#readme",
+  "homepage": "https://github.com/usapopopooon/bf-i18n#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/usapopopooon/backend-friendly-i18n.git",
+    "url": "git+https://github.com/usapopopooon/bf-i18n.git",
     "directory": "packages/core"
   },
   "bugs": {
-    "url": "https://github.com/usapopopooon/backend-friendly-i18n/issues"
+    "url": "https://github.com/usapopopooon/bf-i18n/issues"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,14 +32,14 @@
   ],
   "author": "",
   "license": "MIT",
-  "homepage": "https://github.com/usapopopooon/backend-friendly-i18n#readme",
+  "homepage": "https://github.com/usapopopooon/bf-i18n#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/usapopopooon/backend-friendly-i18n.git",
+    "url": "git+https://github.com/usapopopooon/bf-i18n.git",
     "directory": "packages/react"
   },
   "bugs": {
-    "url": "https://github.com/usapopopooon/backend-friendly-i18n/issues"
+    "url": "https://github.com/usapopopooon/bf-i18n/issues"
   },
   "scripts": {
     "build": "tsup",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -32,14 +32,14 @@
   ],
   "author": "",
   "license": "MIT",
-  "homepage": "https://github.com/usapopopooon/backend-friendly-i18n#readme",
+  "homepage": "https://github.com/usapopopooon/bf-i18n#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/usapopopooon/backend-friendly-i18n.git",
+    "url": "git+https://github.com/usapopopooon/bf-i18n.git",
     "directory": "packages/vue"
   },
   "bugs": {
-    "url": "https://github.com/usapopopooon/backend-friendly-i18n/issues"
+    "url": "https://github.com/usapopopooon/bf-i18n/issues"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION
## Summary
- Rename repository from `backend-friendly-i18n` to `bf-i18n`
- Update all package URLs (homepage, repository, bugs) to use new repository name

## Test plan
- [x] Verify all package.json URLs point to the new repository name
- [x] Confirm CHANGELOG.md is updated with v0.5.3 entry