### PR TITLE
Release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.4] - 2026-01-01
+
+### Changed
+
+#### Documentation
+- Update README.md, LICENSE, and root package.json to use `bf-i18n` name
+
 ## [0.5.3] - 2026-01-01
 
 ### Changed

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 backend-friendly-i18n contributors
+Copyright (c) 2026 bf-i18n contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# backend-friendly-i18n
+# bf-i18n
 
-[![CI](https://github.com/usapopopooon/backend-friendly-i18n/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/backend-friendly-i18n/actions/workflows/ci.yml)
+[![CI](https://github.com/usapopopooon/bf-i18n/actions/workflows/ci.yml/badge.svg)](https://github.com/usapopopooon/bf-i18n/actions/workflows/ci.yml)
 [![npm version](https://img.shields.io/npm/v/@bf-i18n/core.svg)](https://www.npmjs.com/package/@bf-i18n/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "backend-friendly-i18n",
+  "name": "bf-i18n",
   "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "backend-friendly-i18n",
+      "name": "bf-i18n",
       "version": "0.0.0",
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend-friendly-i18n",
+  "name": "bf-i18n",
   "version": "0.0.0",
   "private": true,
   "description": "Rails/Laravel i18n format compatible library for React/Vue",


### PR DESCRIPTION
## Summary
- Update README.md, LICENSE, and root package.json to use `bf-i18n` name

## Test plan
- [x] Verify all references to `backend-friendly-i18n` have been updated
- [x] Confirm CHANGELOG.md is updated with v0.5.4 entry